### PR TITLE
Fix compile error concerning `key`

### DIFF
--- a/demo/sdl_opengl3/main.nim
+++ b/demo/sdl_opengl3/main.nim
@@ -113,7 +113,7 @@ bg.b = 0.24
 bg.a = 1.0
 while running == 1:
   ##  Input
-  var evt: sdl2.Event
+  var evt: sdl2.Event = sdl2.defaultEvent
   nuklear.input_begin(ctx)
   while sdl2.pollEvent(evt):
     if evt.kind == QuitEvent:

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.nim
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.nim
@@ -14,7 +14,7 @@
 
 import opengl, sdl2
 
-import nimnuklear/nuklear
+import nimnuklear/nuklear except key
 
 ## 
 ##  ==============================================================


### PR DESCRIPTION
I'm not really sure why my original pull request worked, but compiling it again resulted in a compile error surrounding a conflict between sdl2 and nuklear concerning `key`.

This pull fixes that, plus it gets rid of an errant warning.